### PR TITLE
back() fix works properly with this line for some reason.

### DIFF
--- a/src/main/java/me/kodysimpson/simpapi/menu/PlayerMenuUtility.java
+++ b/src/main/java/me/kodysimpson/simpapi/menu/PlayerMenuUtility.java
@@ -76,6 +76,7 @@ public class PlayerMenuUtility {
      * @return Get the previous menu that was opened for the player
      */
     public Menu lastMenu(){
+        this.history.pop(); //Makes back() work for some reason
         return this.history.pop();
     }
 


### PR DESCRIPTION
Im not sure why this works, but it just does. I did test it with multiple menus, and it still works with those. If anyone can tell me why this works, it would be great :+1: .