### PR TITLE
Feature/subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ buildNumber.properties
 
 # Common working directory
 run/
+target/

--- a/src/main/java/me/kodysimpson/simpapi/command/CommandManager.java
+++ b/src/main/java/me/kodysimpson/simpapi/command/CommandManager.java
@@ -21,6 +21,12 @@ public class CommandManager {
         return clazz.isAnnotationPresent(QualifiedSubCommand.class);
     }
 
+    private static List<String> fetchAliasesForSubcommand(Class<? extends SubCommand> clazz) {
+        if(!isQualifiedSubcommand(clazz)) return Collections.emptyList();
+        QualifiedSubCommand marker = clazz.getAnnotation(QualifiedSubCommand.class);
+        return Arrays.asList(marker.aliases);
+    }
+
     /**
      * @param plugin An instance of your plugin that is using this API. If called within plugin main class, provide this keyword
      * @param commandName The name of the command
@@ -46,7 +52,7 @@ public class CommandManager {
 
                 //Should this subcommand be treated as an independent command in its own right?
                 if(isQualifiedSubcommand(subcommand)) {
-                    createCoreCommand(plugin, sub.getName(), sub.getDescription(), sub.getSyntax(), commandList, sub.getAliases());
+                    createCoreCommand(plugin, sub.getName(), sub.getDescription(), sub.getSyntax(), commandList, fetchAliasesForSubcommand(subcommand));
                 }
 
                 return sub;

--- a/src/main/java/me/kodysimpson/simpapi/command/CommandManager.java
+++ b/src/main/java/me/kodysimpson/simpapi/command/CommandManager.java
@@ -17,6 +17,10 @@ import java.util.List;
  */
 public class CommandManager {
 
+    private static boolean isQualifiedSubcommand(Class<? extends SubCommand> clazz) {
+        return clazz.isAnnotationPresent(QualifiedSubCommand.class);
+    }
+
     /**
      * @param plugin An instance of your plugin that is using this API. If called within plugin main class, provide this keyword
      * @param commandName The name of the command
@@ -38,8 +42,15 @@ public class CommandManager {
         Arrays.stream(subcommands).map(subcommand -> {
             try{
                 Constructor<? extends SubCommand> constructor = subcommand.getConstructor();
-                return constructor.newInstance();
-            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+                SubCommand sub = constructor.newInstance();
+
+                //Should this subcommand be treated as an independent command in its own right?
+                if(isQualifiedSubcommand(subcommand)) {
+                    createCoreCommand(plugin, sub.getName(), sub.getDescription(), sub.getSyntax(), commandList, sub.getAliases());
+                }
+
+                return sub;
+            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException | NoSuchFieldException e) {
                 e.printStackTrace();
             }
             return null;

--- a/src/main/java/me/kodysimpson/simpapi/command/CommandManager.java
+++ b/src/main/java/me/kodysimpson/simpapi/command/CommandManager.java
@@ -52,7 +52,14 @@ public class CommandManager {
 
                 //Should this subcommand be treated as an independent command in its own right?
                 if(isQualifiedSubcommand(subcommand)) {
-                    createCoreCommand(plugin, sub.getName(), sub.getDescription(), sub.getSyntax(), commandList, fetchAliasesForSubcommand(subcommand));
+                    createCoreCommand(
+                            plugin,
+                            sub.getName(),
+                            sub.getDescription(),
+                            sub.getSyntax(),
+                            commandList,
+                            fetchAliasesForSubcommand(subcommand)
+                    );
                 }
 
                 return sub;

--- a/src/main/java/me/kodysimpson/simpapi/command/QualifiedSubCommand.java
+++ b/src/main/java/me/kodysimpson/simpapi/command/QualifiedSubCommand.java
@@ -1,0 +1,10 @@
+package me.kodysimpson.simpapi.command;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface QualifiedSubCommand {}

--- a/src/main/java/me/kodysimpson/simpapi/command/QualifiedSubCommand.java
+++ b/src/main/java/me/kodysimpson/simpapi/command/QualifiedSubCommand.java
@@ -7,4 +7,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface QualifiedSubCommand {}
+public @interface QualifiedSubCommand {
+    String[] aliases = { "" };
+}


### PR DESCRIPTION
Closes #17
Adds a new marker annotation called `QualifiedSubCommand`:
```java
@QualifiedSubCommand(aliases = {"commandalias"})
class MySubCommand extends SubCommand {
   //....
}
```

This registers the subcommand as it would normally, but also registers it as a base command.
The annotation optionally takes an aliases parameter.


### ***Disclaimer***: I have no means of testing this. I don't see why it wouldn't work, but yeah.