### PR TITLE
Clarified README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,10 @@ JavaDocs: https://kodysimpson.github.io/SimpAPI/index.html
 
 #### Repository
 ```xml
-<repositories>
-    <repository>
-        <id>jitpack.io</id>
-        <url>https://jitpack.io</url>
-    </repository>
-</repositories>
+<repository>
+    <id>jitpack.io</id>
+    <url>https://jitpack.io</url>
+</repository>
 ```
 #### Dependency
 ```xml


### PR DESCRIPTION
Below the dependency does not show the parent dependencies block as it is implied that you put the dependency in the dependencies block. However, the repositories block was shown for the repositories. While I think that either approach, (showing or not showing the block) is fine, the project should choose one. I chose the no-parent block option as it is more common.