### PR TITLE
Improved Playersafe in PlayerMenuUtilityMap and PlayerMenuUtility

### DIFF
--- a/src/main/java/me/kodysimpson/simpapi/menu/MenuManager.java
+++ b/src/main/java/me/kodysimpson/simpapi/menu/MenuManager.java
@@ -10,6 +10,7 @@ import org.bukkit.plugin.RegisteredListener;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
+import java.util.UUID;
 
 /**
  * Used to interface with the Menu Manager API
@@ -17,7 +18,7 @@ import java.util.HashMap;
 public class MenuManager {
 
     //each player will be assigned their own PlayerMenuUtility object
-    private static final HashMap<Player, PlayerMenuUtility> playerMenuUtilityMap = new HashMap<>();
+    private static final HashMap<UUID, PlayerMenuUtility> playerMenuUtilityMap = new HashMap<>();
     private static boolean isSetup = false;
 
     private static void registerMenuListener(Server server, Plugin plugin) {
@@ -70,15 +71,15 @@ public class MenuManager {
         }
 
         PlayerMenuUtility playerMenuUtility;
-        if (!(playerMenuUtilityMap.containsKey(p))) { //See if the player has a pmu "saved" for them
+        if (!(playerMenuUtilityMap.containsKey(p.getUniqueId()))) { //See if the player has a pmu "saved" for them
 
             //Construct PMU
             playerMenuUtility = new PlayerMenuUtility(p);
-            playerMenuUtilityMap.put(p, playerMenuUtility);
+            playerMenuUtilityMap.put(p.getUniqueId(), playerMenuUtility);
 
             return playerMenuUtility;
         } else {
-            return playerMenuUtilityMap.get(p); //Return the object by using the provided player
+            return playerMenuUtilityMap.get(p.getUniqueId()); //Return the object by using the provided player
         }
     }
 

--- a/src/main/java/me/kodysimpson/simpapi/menu/PlayerMenuUtility.java
+++ b/src/main/java/me/kodysimpson/simpapi/menu/PlayerMenuUtility.java
@@ -7,23 +7,25 @@ Companion class to all menus. This is needed to pass information across the enti
  Each player has one of these objects, and only one.
  */
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
 import java.util.Stack;
+import java.util.UUID;
 
 public class PlayerMenuUtility {
 
-    private final Player owner;
+    private final UUID owner;
     private final HashMap<String, Object> dataMap = new HashMap<>();
     private final Stack<Menu> history = new Stack<>();
 
     public PlayerMenuUtility(Player p) {
-        this.owner = p;
+        this.owner = p.getUniqueId();
     }
 
     public Player getOwner() {
-        return owner;
+        return Bukkit.getPlayer(owner);
     }
 
     /**


### PR DESCRIPTION
After relogging, you can no longer access the menu because the player instance is refreshed and no longer matches the saved one. With this small change, it works fine again.